### PR TITLE
add an option to view on chrome canary

### DIFF
--- a/adb_profile_chrome.py
+++ b/adb_profile_chrome.py
@@ -434,8 +434,8 @@ When in doubt, just try out --trace-frame-viewer.
                                 options.json)
   if options.view_canary:
     if sys.platform == 'darwin':
-      os.system(('/usr/bin/open -a /Applications/Google\ Chrome\ Canary.app %s'
-                '--enable-impl-side-painting --enable-skia-benchmarking'
+      os.system(('/usr/bin/open -a /Applications/Google\ Chrome\ Canary.app %s '
+                '--args --enable-impl-side-painting --enable-skia-benchmarking '
                 '--allow-webui-compositing') % os.path.abspath(result))
     else:
       _PrintMessage('No Chrome Canary on this platform to open trace in, try a different view method')


### PR DESCRIPTION
Only works on Mac atm, but can add Windows support if anyone cares.

I find this is useful because tracing doesn't always work right in older version of Chrome (default browser).
